### PR TITLE
Set merge=union on index.html

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+./index.html merge=union

--- a/index.html
+++ b/index.html
@@ -169,6 +169,7 @@ and are not intended to imply an endorsement by the organization.
 <li><a href="https://twitter.com/edropple">Ed Ropple, edboxes</a>
 <li><a href="https://twitter.com/ecenanovic">Edin Cenanovic, Software Engineer</a> <!-- from GitHub user edinc -->
 <li><a href="https://twitter.com/lcdpowell">Elsie Powell, 2U</a> <!-- from GitHub user embolalia -->
+<li><a href="https://emmah.net/">Emma Claire Humphries</a>, Mozilla Corporation <!-- from GitHub user emceeaich -->
 <li>Erik Ogan, Principal Engineer, <a href="https://www.change.org/">Change.org</a> <!-- from GitHub user erikogan -->
 <li>Erin Ptacek, Latacora
 <li>Ethan Schlenker, Twitter

--- a/index.html
+++ b/index.html
@@ -159,6 +159,7 @@ and are not intended to imply an endorsement by the organization.
 <li>David Beckley
 <li><a href="https://twitter.com/davigoli">David Golightly, Software Developer, Substantial</a>
 <li>David Hartunian, Position Development <!-- from GitHub user dhartunian -->
+<li>David Nielsen <!-- from GitHub user attackcowboy -->
 <li>David Reid, Engineer, Fig <!-- from GitHub user dreid -->
 <li><a href="http://twitter.com/davidnwelton">David Welton</a></li> <!-- from Github user davidw -->
 <li>Don Marti, Mozilla <!-- from GitHub user dmarti -->


### PR DESCRIPTION
Since we're usually just appending lines to the file, it might make
sense to tell git to merge the file as union and not omit lines
that were missing on the branch if master has had them added.

source:
https://krlmlr.github.io/using-gitattributes-to-avoid-merge-conflicts/

Text from git docs:
https://git-scm.com/docs/gitattributes
> Run 3-way file level merge for text files, but take lines from both
> versions, instead of leaving conflict markers. This tends to leave the
> added lines in the resulting file in random order and the user should
> verify the result. Do not use this if you do not understand the
> implications.