### PR TITLE
Adding myself, Aki Braun

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,6 +125,7 @@ and are not intended to imply an endorsement by the organization.
 <!--   - Consider including your GitHub username (see examples below).     -->
 
 <li>Aaron Kraus, Reciprocity, Inc. <!-- from verified email -->
+<li><a href="https://twitter.com/gesa">Aki Rose Braun</a>, <a href="https://github.com/gesa">Programmer</a>, PayPal/Venmo</li>
 <li>Akil Harris, First Look Media
 <li>Alec Perkins <!-- from GitHub user alecperkins -->
 <li><a href="https://twitter.com/cubeghost">Alex Baldwin, Poncho</a> <!-- from GitHub user goosey -->


### PR DESCRIPTION
There has been a lot of noise made internally by employees at Braintree and Venmo (both owned by PayPal) about making sure we are public about the fact that Peter Thiel has been divested from PayPal for a very long time. We were the first org to make noise about doing business in North Carolina after HB2 was passed. We will keep making noise against fascism.