### PR TITLE
Small grammar and capitalization changes to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 If you're interested in signing the pledge, please submit a PR against index.html, following the instructions in the HTML comments there. Add your name to the list in alphabetical order, to minimize merge conflicts.
 
-If Github isn't your jam, you can [send us a direct message us on Twitter (our DMs are open)](https://twitter.com/neveragaintech).
+If GitHub isn't your jam, you can [send us a direct message on Twitter (our DMs are open)](https://twitter.com/neveragaintech).
 
 If neither of these options are possible, please email neveragaindottech at gmail dot com, but please note that this may delay your signature as we must validate your identity. Please send us some way for us to confirm your identity, such as a LinkedIn profile or a homepage.


### PR DESCRIPTION
Just a couple of text changes to the README. 

- Capitalizes the H in Github
- Removes redundant 'us' 

Thank you for creating this project. 
