### PR TITLE
Update my earlier signature

### DIFF
--- a/_includes/earlier_signatures.html
+++ b/_includes/earlier_signatures.html
@@ -126,7 +126,7 @@
 <li>Dan Kurtz, Software Developer
 <li><a href="https://phiffer.org/">Dan Phiffer, Mapzen</a> <!-- from GitHub user dphiffer -->
 <li>Dan Wood
-<li><a href="http://danielespeset.com">Daniel Espeset</a>, Etsy <!-- from GitHub user danielmendel -->
+<li><a href="http://danielespeset.com">Daniel Espeset</a> <!-- from GitHub user danielmendel -->
 <li>Daniel Miles <!-- from GitHub user danieltmiles -->
 <li><a href="https://www.linkedin.com/in/dtunkelang">Daniel Tunkelang</a>
 <li>Danielle Dunne


### PR DESCRIPTION
Removing my employer attribution because I've decided this pledge is about publicly committing to my ethics as a professional software engineer – whoever is currently employing me is immaterial.