### PR TITLE
Updating my signature

### DIFF
--- a/_signatures/Daniel_Espeset.md
+++ b/_signatures/Daniel_Espeset.md
@@ -1,6 +1,5 @@
 ---
   name: Daniel Espeset
   link: http://danielespeset.com
-  affiliation: Etsy 
   github: danielmendel
 ---


### PR DESCRIPTION
Removing my attribution because I've decided this pledge is about publicly committing to my ethics as a professional software engineer – whoever is currently employing me is immaterial.