### PR TITLE
Fix signature formatting and HTML validation errors

### DIFF
--- a/_includes/main_content.html
+++ b/_includes/main_content.html
@@ -1,4 +1,4 @@
-<blockquote><em>Write a list of things you would never do. Because it is possible that in the next year, you will do them.</em> &mdash;Sarah Kendzior <a href="#footnote1">[1]</a></blockquote>
+<blockquote><em>Write a list of things you would never do. Because it is possible that in the next year, you will do them.</em> <span class="nobr">&mdash;Sarah Kendzior</span> <a href="#footnote1">[1]</a></blockquote>
 
 <p>
 We, the undersigned,
@@ -27,7 +27,7 @@ precipitated the very atrocity the word genocide
 was <a href="https://en.wiktionary.org/wiki/genocide#Etymology">created</a> to describe:
 the murder of 1.5 million Armenians in Turkey.
 We acknowledge that
-genocides are not merely a relic of the distant past&mdash;<wbr>among others,
+genocides are not merely a relic of the distant <span class="nobr">past&mdash;</span><wbr>among others,
 <a href="http://www.rwandanstories.org/genocide/hate_radio.html">Tutsi Rwandans</a> and
 <a href="https://en.wikipedia.org/wiki/Bosnian_genocide">Bosnian Muslims</a>
 have been victims in our lifetimes.

--- a/_includes/main_content.html
+++ b/_includes/main_content.html
@@ -1,6 +1,6 @@
 <section class="main-content">
     
-<blockquote><em>Write a list of things you would never do. Because it is possible that in the next year, you will do them.</em> <nobr>&mdash;Sarah Kendzior</nobr> <a href="#footnote1">[1]</a></blockquote>
+<blockquote><em>Write a list of things you would never do. Because it is possible that in the next year, you will do them.</em> &mdash;Sarah Kendzior <a href="#footnote1">[1]</a></blockquote>
 
 <p>
 We, the undersigned,
@@ -29,7 +29,7 @@ precipitated the very atrocity the word genocide
 was <a href="https://en.wiktionary.org/wiki/genocide#Etymology">created</a> to describe:
 the murder of 1.5 million Armenians in Turkey.
 We acknowledge that
-genocides are not merely a relic of the distant <nobr>past&mdash;</nobr><wbr>among others,
+genocides are not merely a relic of the distant past&mdash;<wbr>among others,
 <a href="http://www.rwandanstories.org/genocide/hate_radio.html">Tutsi Rwandans</a> and
 <a href="https://en.wikipedia.org/wiki/Bosnian_genocide">Bosnian Muslims</a>
 have been victims in our lifetimes.
@@ -86,5 +86,6 @@ Note: Signatories&rsquo; references to affiliated organizations below
 are for identification purposes
 and are not intended to imply an endorsement by the organization.
 </div>
+</section>
 
 <p>Signed,</p>

--- a/_includes/main_content.html
+++ b/_includes/main_content.html
@@ -1,5 +1,3 @@
-<section class="main-content">
-    
 <blockquote><em>Write a list of things you would never do. Because it is possible that in the next year, you will do them.</em> &mdash;Sarah Kendzior <a href="#footnote1">[1]</a></blockquote>
 
 <p>

--- a/_includes/main_content.html
+++ b/_includes/main_content.html
@@ -86,6 +86,5 @@ Note: Signatories&rsquo; references to affiliated organizations below
 are for identification purposes
 and are not intended to imply an endorsement by the organization.
 </div>
-</section>
 
 <p>Signed,</p>

--- a/_includes/resources.html
+++ b/_includes/resources.html
@@ -53,7 +53,7 @@ some things you can do include:</p>
 <ul>
   <li><a href="http://www.nybooks.com/daily/2016/11/10/trump-election-autocracy-rules-for-survival/">Autocracy: Rules for Survival</a> by Masha Gessen
   <li><a href="http://www.nybooks.com/daily/2016/11/27/trump-realism-vs-moral-politics-choice-we-face/">Trump: The Choice We Face</a> by Masha Gessen
-  <li><a href="https://thecorrespondent.com/5696/were-heading-into-dark-times-this-is-how-to-be-your-own-light-in-the-age-of-trump/1611114266432-e23ea1a6">We’re heading into dark times. This is how to be your own light in the Age of Trump</a> by Sarah Kendzior</a>
+  <li><a href="https://thecorrespondent.com/5696/were-heading-into-dark-times-this-is-how-to-be-your-own-light-in-the-age-of-trump/1611114266432-e23ea1a6">We’re heading into dark times. This is how to be your own light in the Age of Trump</a> by Sarah Kendzior
   <li><a href="http://qz.com/846940/a-yale-history-professors-20-point-guide-to-defending-democracy-under-a-trump-presidency/">A Yale history professor’s powerful, 20-point guide to defending democracy under a Trump presidency</a> by Timothy Snyder
 </ul>
 

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -31,3 +31,4 @@
 {% include how_to_sign.html %}
 
 {% include resources.html %}
+</section>

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -1,5 +1,6 @@
 {% include header.html %}
 
+<section class="main-content">
 {% include main_content.html %}
 
 {% include earlier_signatures.html %}

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -7,24 +7,12 @@
 <ul class="signatories" id="automated-signatories">
   {% assign sorted_signatures =  site.signatures | sort: 'name' %}
   {% for signature in sorted_signatures %}
-    <li>
-      {% if signature.link %}
-        <a href="{{ signature.link }}">{{ signature.name }}</a>
-      {% else %}
-        {{ signature.name }}
-      {% endif %}
-
-      {% if signature.affiliation %}
-      , {{ signature.affiliation }}
-      {% endif %}
-
-      {% if signature.occupation_title %}
-      , {{ signature.occupation_title }}
-      {% endif %}
-    </li>
-    {% if signature.github %}
-    <!-- Github user: {{ signature.github }} -->
-    {% endif %}
+  <li>
+    {% if signature.link %}<a href="{{ signature.link }}">{{ signature.name }}</a>{% else %}{{ signature.name }}{% endif %}{% if signature.affiliation %}, {{ signature.affiliation }} {% endif %}{% if signature.occupation_title %}, {{ signature.occupation_title }}{% endif %}
+  </li>
+  {% if signature.github %}
+  <!-- Github user: {{ signature.github }} -->
+  {% endif %}
   {% endfor %}
 </ul>
 

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -187,3 +187,4 @@ h1 { font-weight: 300; text-align: left; }
 ul { list-style-type: disc; }
 a { color: #06c; text-decoration: none; }
 a:hover { text-decoration: underline; }
+.nobr { white-space: nowrap; }


### PR DESCRIPTION
This PR fixes two issues I saw.

The signatures are currently formatted with a space between the name and the comma:
<img width="245" alt="screen shot 2016-12-14 at 5 57 35 pm" src="https://cloud.githubusercontent.com/assets/1648519/21204752/d2cb129c-c226-11e6-8c8c-890df10f0fbc.png">

In my opinion, this doesn't look correct, so I put all of the Jekyll signature-related templating onto a single line. This makes the code a little more gross but fixes this issue. As far as I can tell this is the only way to deal with the huge amount of whitespace Jekyll spews everywhere and fix the spacing issue. Now it looks like this:

<img width="344" alt="screen shot 2016-12-14 at 6 05 14 pm" src="https://cloud.githubusercontent.com/assets/1648519/21204977/e5e0aab2-c227-11e6-974e-1687526953a9.png">

Additionally, I made the HTML valid fixing a couple of tags that weren't closed and removing tags like `<nobr>` which are non-standard and shouldn't be used or relied upon.