### PR TITLE
Swap order from affiliation, role to idiomatic role, affiliation

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -9,7 +9,7 @@
   {% assign sorted_signatures =  site.signatures | sort: 'name' %}
   {% for signature in sorted_signatures %}
   <li>
-    {% if signature.link %}<a href="{{ signature.link }}">{{ signature.name }}</a>{% else %}{{ signature.name }}{% endif %}{% if signature.affiliation %}, {{ signature.affiliation }}{% endif %}{% if signature.occupation_title %}, {{ signature.occupation_title }}{% endif %}
+    {% if signature.link %}<a href="{{ signature.link }}">{{ signature.name }}</a>{% else %}{{ signature.name }}{% endif %}{% if signature.occupation_title %}, {{ signature.occupation_title }}{% endif %}{% if signature.affiliation %}, {{ signature.affiliation }}{% endif %}
   </li>
   {% if signature.github %}
   <!-- Github user: {{ signature.github }} -->


### PR DESCRIPTION
It is typical to see `J. Random, Hacker, Data Corp` rather than `J.
Random, Data Corp, Hacker`.

A number of signatories put their affiliation and role into one field
in order to achieve this ordering, but since it's the most common it
should probably be the default.