### PR TITLE
Remove info about Twitter DMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 If you're interested in signing [the pledge](http://neveragain.tech/), please submit a PR by creating a new file in the `_signatures` folder, following the instructions listed below in the section titled, "To add your name via Github"
 
-If GitHub isn't your jam, you can [send us a direct message on Twitter (our DMs are open)](https://twitter.com/neveragaintech).
-
-If neither of these options are possible, please email neveragaindottech at gmail dot com, but please note that this may delay your signature as we must validate your identity. Please send us some way for us to confirm your identity, such as a LinkedIn profile or a homepage.
+If this option isn't possible, please email neveragaindottech at gmail dot com, but please note that this may delay your signature as we must validate your identity. Please send us some way for us to confirm your identity, such as a LinkedIn profile or a homepage.
 
 ## To add your name via Github
 

--- a/_includes/how_to_sign.html
+++ b/_includes/how_to_sign.html
@@ -9,10 +9,8 @@ exactly as you would like to be listed here,
 in one of the following ways:
 <ul>
   <li><a href="https://github.com/neveragaindottech/neveragaindottech.github.io/">Send us a pull request on GitHub.</a>
-  <li><a href="https://twitter.com/neveragaintech">Direct message us on Twitter (our DMs are open).</a>
-  <li>If neither of these options are possible,
-  please email neveragaindottech at gmail dot com,
-  but please note that this may delay your signature
+  <li>Email neveragaindottech at gmail dot com.
+  Please note that this may delay your signature
   as we must validate your identity.
   Please send us some way for us to confirm your identity,
   such as a LinkedIn profile or a homepage.


### PR DESCRIPTION
This PR removes info about signing via Twitter DM, as [DMs are no longer open](https://twitter.com/neveragaintech/status/809263643317542912).