### PR TITLE
Changed government to be inclusive of non-US folks

### DIFF
--- a/_includes/main_content.html
+++ b/_includes/main_content.html
@@ -41,7 +41,7 @@ We commit to the following actions:
 <ul>
   <li>We refuse to participate in the creation of
   databases of identifying information
-  for the United States government
+  for any government, be it our own or foreign,
   to target individuals based on race, religion, or national origin.
 
   <li>We will advocate within our organizations:


### PR DESCRIPTION
Changed "United States Government" to "any government" as the current definition includes only 4.4% of the world population.

Feel free to instead make your own change, as english is my second language and wording is very important in this specifically. Currently the text gives the impression that it's ok to give data to any other government, which is interesting seeing as only one of the named examples was done by the US Government.