### PR TITLE
Add link to signing instructions above signature

### DIFF
--- a/_includes/how_to_sign.html
+++ b/_includes/how_to_sign.html
@@ -1,5 +1,5 @@
 
-<h2>How to sign this pledge</h2>
+<a name="howtosign"></a><h2>How to sign this pledge</h2>
 
 <p>To sign this pledge, please
 <a href="https://github.com/neveragaindottech/neveragaindottech.github.io/blob/master/README.md">follow these instructions</a>.

--- a/_includes/main_content.html
+++ b/_includes/main_content.html
@@ -81,6 +81,8 @@ We commit to the following actions:
   beyond our organization and our industry.
 </ul>
 
+<p><a href="#howtosign">Jump to instructions on how to sign this pledge</a></p>
+
 <p class="note">
 Note: Signatories&rsquo; references to affiliated organizations below
 are for identification purposes


### PR DESCRIPTION
Now that we have over 1500 signatures, make it easier to get to the
signing instructions by adding an HTML anchor and a link.