### PR TITLE
SignBot: Add signatory 'Andrew Godwin' (andrewgodwin)

### DIFF
--- a/_signatures/auZIJnxsCwWtbFMrwb8zSUiN3of2.md
+++ b/_signatures/auZIJnxsCwWtbFMrwb8zSUiN3of2.md
@@ -1,0 +1,6 @@
+---
+  name: "Andrew Godwin"
+  link: http://www.aeracode.org
+  affiliation: "Eventbrite"
+  occupation_title: "Senior Software Engineer"
+---


### PR DESCRIPTION
Twitter user: https://twitter.com/andrewgodwin
Created: 2007-09-08 18:13:54 +0000 UTC, Followers: 6955, Following: 289, Tweets: 7554, Egg: false

Twitter profile fields:
Name: Andrew Godwin
Website: https://t.co/RpbZd1rfMU
Tagline: Django core developer, engineer @eventbrite, private pilot, archer, and misplaced Brit. He/him.

Personal page: http://www.aeracode.org

Signature file contents:
```
---
  name: "Andrew Godwin"
  link: http://www.aeracode.org
  affiliation: "Eventbrite"
  occupation_title: "Senior Software Engineer"
---

```