### PR TITLE
SignBot: Add signatory 'Brian Gesiak' (modocache)

### DIFF
--- a/_signatures/JUAyLqyjpTbbvfRK2bmig7QYUmi1.md
+++ b/_signatures/JUAyLqyjpTbbvfRK2bmig7QYUmi1.md
@@ -1,0 +1,6 @@
+---
+  name: "Brian Gesiak"
+  link: https://twitter.com/modocache
+  affiliation: "Facebook"
+  occupation_title: "Software Engineer"
+---


### PR DESCRIPTION
Twitter user: https://twitter.com/modocache
Created: 2010-09-19 07:51:23 +0000 UTC, Followers: 6160, Following: 215, Tweets: 7254, Egg: false

Twitter profile fields:
Name: Brian Gesiak
Website: https://t.co/mMBoPj4DTd
Tagline: LLVM, Swift, and swift-corelibs-xctest committer. Creator of Quick, the Swift (and Objective-C) testing framework. Former Japanese literature translator.

Personal page: http://modocache.io

Signature file contents:
```
---
  name: "Brian Gesiak"
  link: https://twitter.com/modocache
  affiliation: "Facebook"
  occupation_title: "Software Engineer"
---

```