### PR TITLE
SignBot: Add signatory 'Stefan Ortloff' (googijh)

### DIFF
--- a/_signatures/aJRTcNoSkOh0nKNmYI4EXARW5Kc2.md
+++ b/_signatures/aJRTcNoSkOh0nKNmYI4EXARW5Kc2.md
@@ -1,0 +1,5 @@
+---
+  name: "Stefan Ortloff"
+  link: https://twitter.com/googijh
+  occupation_title: "Security Researcher"
+---


### PR DESCRIPTION
Twitter user: https://twitter.com/googijh
Created: 2009-05-12 21:06:34 +0000 UTC, Followers: 1253, Following: 2366, Tweets: 1631, Egg: false

Twitter profile fields:
Name: stefan ortloff
Website: 
Tagline: Loves his daughter, his job, Mr.Sepp the cat, electronic music, linux,coding; @Kaspersky Global Research & Analysis Team - Tweets own views only. PGP: 84010E5D

Personal page: https://de.linkedin.com/in/stefan-ortloff-3093454a

Signature file contents:
```
---
  name: "Stefan Ortloff"
  link: https://twitter.com/googijh
  occupation_title: "Security Researcher"
---

```