### PR TITLE
SignBot: Add signatory 'Nnamdi Ofodile' (NamOf)

### DIFF
--- a/_signatures/uyd3rrWFZ5hLRnWKWVk1PnhAqBr1.md
+++ b/_signatures/uyd3rrWFZ5hLRnWKWVk1PnhAqBr1.md
@@ -1,0 +1,6 @@
+---
+  name: "Nnamdi Ofodile"
+  link: https://twitter.com/NamOf
+  affiliation: "Google"
+  occupation_title: "Global Partnership Manager, Android & Chrome"
+---


### PR DESCRIPTION
Twitter user: https://twitter.com/NamOf
Created: 2009-02-02 16:53:28 +0000 UTC, Followers: 267, Following: 326, Tweets: 1614, Egg: false

Twitter profile fields:
Name: Nnamdi Ofodile
Website: 
Tagline: Mobile tech fan in the office (@divide @google) and home. Long suffering Mets/Jets/Nets fan. Tech tweets will be happy, sports tweets, not so much.

Personal page: 

Signature file contents:
```
---
  name: "Nnamdi Ofodile"
  link: https://twitter.com/NamOf
  affiliation: "Google"
  occupation_title: "Global Partnership Manager, Android & Chrome"
---

```