### PR TITLE
SignBot: Add signatory 'Benjamin Rahn' (brahn)

### DIFF
--- a/_signatures/inCvKn4TjbRtNpKHmhmDRIHDQ0j2.md
+++ b/_signatures/inCvKn4TjbRtNpKHmhmDRIHDQ0j2.md
@@ -1,0 +1,5 @@
+---
+  name: "Benjamin Rahn"
+  link: https://twitter.com/brahn
+  affiliation: "Stripe"
+---


### PR DESCRIPTION
Twitter user: https://twitter.com/brahn
Created: 2007-08-01 01:12:54 +0000 UTC, Followers: 988, Following: 733, Tweets: 2134, Egg: false

Twitter profile fields:
Name: Benjamin Rahn
Website: 
Tagline: Dad.  Product engineering at https://t.co/RvQvsvPvES  Co-founded https://t.co/wdlUwygM9n  Erstwhile physicist.

Personal page: 

Signature file contents:
```
---
  name: "Benjamin Rahn"
  link: https://twitter.com/brahn
  affiliation: "Stripe"
---

```