### PR TITLE
SignBot: Add signatory 'Alan Stearns' (alanstearns)

### DIFF
--- a/_signatures/NtfSEEGTZ8dahAjydV9LRL7MXMP2.md
+++ b/_signatures/NtfSEEGTZ8dahAjydV9LRL7MXMP2.md
@@ -1,0 +1,6 @@
+---
+  name: "Alan Stearns"
+  link: https://twitter.com/alanstearns
+  affiliation: "Adobe Systems"
+  occupation_title: "CSS Panjandrum"
+---


### PR DESCRIPTION
Twitter user: https://twitter.com/alanstearns
Created: 2009-07-21 20:53:27 +0000 UTC, Followers: 547, Following: 221, Tweets: 1203, Egg: false

Twitter profile fields:
Name: Alan Stearns
Website: 
Tagline: CSS Panjandrum at Adobe Systems. Co-Chair of the CSSWG. Runs the Formidable Open Device Lab https://t.co/XLoCckp13p

Personal page: 

Signature file contents:
```
---
  name: "Alan Stearns"
  link: https://twitter.com/alanstearns
  affiliation: "Adobe Systems"
  occupation_title: "CSS Panjandrum"
---

```