### PR TITLE
SignBot: Add signatory 'Chris Thoma' (ChrisThoma)

### DIFF
--- a/_signatures/a5rR38HUGGbzMBrTiCuE5FIip753.md
+++ b/_signatures/a5rR38HUGGbzMBrTiCuE5FIip753.md
@@ -1,0 +1,5 @@
+---
+  name: "Chris Thoma"
+  affiliation: "Apple"
+  occupation_title: "Software Engineer"
+---


### PR DESCRIPTION
Twitter user: https://twitter.com/ChrisThoma
Created: 2008-04-23 01:32:08 +0000 UTC, Followers: 188, Following: 281, Tweets: 5725, Egg: false

Twitter profile fields:
Name: Chris Thoma
Website: 
Tagline: Nostalgic for garbage // Desperate for time

Personal page: 

Signature file contents:
```
---
  name: "Chris Thoma"
  affiliation: "Apple"
  occupation_title: "Software Engineer"
---

```