### PR TITLE
SignBot: Add signatory 'Nicholas Heidke' (NickHeidke)

### DIFF
--- a/_signatures/KFaDwNjZqkgU49oQNVSPk0AUI3z1.md
+++ b/_signatures/KFaDwNjZqkgU49oQNVSPk0AUI3z1.md
@@ -1,0 +1,5 @@
+---
+  name: "Nicholas Heidke"
+  link: https://twitter.com/NickHeidke
+  occupation_title: "ETL Developer"
+---


### PR DESCRIPTION
Twitter user: https://twitter.com/NickHeidke
Created: 2009-03-04 02:01:51 +0000 UTC, Followers: 359, Following: 327, Tweets: 5986, Egg: false

Twitter profile fields:
Name: Nick Heidke
Website: http://t.co/1NlR80cAIv
Tagline: software engineer, data detective, whiteboard abuser, madisonian, tv junkie, football enthusiast, dedicated husband & father

Personal page: 

Signature file contents:
```
---
  name: "Nicholas Heidke"
  link: https://twitter.com/NickHeidke
  occupation_title: "ETL Developer"
---

```