### PR TITLE
SignBot: Add signatory 'Cory Benfield' (Lukasaoz)

### DIFF
--- a/_signatures/AfGFAmFiHyOcNeqIXDL2EIUdQG23.md
+++ b/_signatures/AfGFAmFiHyOcNeqIXDL2EIUdQG23.md
@@ -1,0 +1,6 @@
+---
+  name: "Cory Benfield"
+  link: https://twitter.com/Lukasaoz
+  affiliation: "Hewlett Packard Enterprise"
+  occupation_title: "Senior Cloud Engineer"
+---


### PR DESCRIPTION
Twitter user: https://twitter.com/Lukasaoz
Created: 2008-12-25 23:33:11 +0000 UTC, Followers: 1431, Following: 405, Tweets: 12157, Egg: false

Twitter profile fields:
Name: Cory Benfield
Website: https://t.co/f2Lojc33gR
Tagline: “Judgemental handwringing PC bollocks” As A Service.

Personal page: https://lukasa.co.uk/about

Signature file contents:
```
---
  name: "Cory Benfield"
  link: https://twitter.com/Lukasaoz
  affiliation: "Hewlett Packard Enterprise"
  occupation_title: "Senior Cloud Engineer"
---
```