### PR TITLE
SignBot: Add signatory 'Avi Douglen' (sec_tigger)

### DIFF
--- a/_signatures/CIXoTxpxNaeNKB6n9fX8Hy27Khe2.md
+++ b/_signatures/CIXoTxpxNaeNKB6n9fX8Hy27Khe2.md
@@ -1,0 +1,5 @@
+---
+  name: "Avi Douglen"
+  link: https://twitter.com/sec_tigger
+  occupation_title: "Security Architect and Researcher"
+---


### PR DESCRIPTION
Twitter user: https://twitter.com/sec_tigger
Created: 2010-11-09 11:26:08 +0000 UTC, Followers: 237, Following: 178, Tweets: 6298, Egg: false

Twitter profile fields:
Name: Avi Douglen
Website: https://t.co/I6yTjlk9vx
Tagline: 'Cuz AppSec is what Tiggers do best! Hoohoo hoo HOOO! And some other stuff, like @OWASP_IL/ @StackSecurity/beer/whisky/wine/...

Personal page: https://www.linkedin.com/in/avidouglen

Signature file contents:
```
---
  name: "Avi Douglen"
  link: https://twitter.com/sec_tigger
  occupation_title: "Security Architect and Researcher"
---
```