### PR TITLE
SignBot: Add signatory 'Glenn Willen' (gwillen)

### DIFF
--- a/_signatures/jRnTMhGFLfSJ9gm5z3hGsKtEJ1e2.md
+++ b/_signatures/jRnTMhGFLfSJ9gm5z3hGsKtEJ1e2.md
@@ -1,0 +1,5 @@
+---
+  name: "Glenn Willen"
+  affiliation: "Blockstream"
+  occupation_title: "Software Engineer"
+---


### PR DESCRIPTION
Twitter user: https://twitter.com/gwillen
Created: 2008-02-15 18:47:10 +0000 UTC, Followers: 468, Following: 404, Tweets: 1872, Egg: true

Twitter profile fields:
Name: gwillen
Website: 
Tagline: Love is all you need. And a broadband connection. And about a pint of Morgan. And sometimes y.

Personal page: https://keybase.io/gwillen

Signature file contents:
```
---
  name: "Glenn Willen"
  affiliation: "Blockstream"
  occupation_title: "Software Engineer"
---
```