### PR TITLE
SignBot: Add signatory 'Allan Shortlidge' (tshortli)

### DIFF
--- a/_signatures/zJhgn0V8c8UEACcklMWjUqcNHPg1.md
+++ b/_signatures/zJhgn0V8c8UEACcklMWjUqcNHPg1.md
@@ -1,0 +1,6 @@
+---
+  name: "Allan Shortlidge"
+  link: https://twitter.com/tshortli
+  affiliation: "Apple"
+  occupation_title: "Software Engineer"
+---


### PR DESCRIPTION
Twitter user: https://twitter.com/tshortli
Created: 2008-08-15 05:30:15 +0000 UTC, Followers: 433, Following: 283, Tweets: 1533, Egg: false

Twitter profile fields:
Name: Allan Shortlidge
Website: 
Tagline: HealthKit Engineer at Apple with a cycling problem

Personal page: 

Signature file contents:
```
---
  name: "Allan Shortlidge"
  link: https://twitter.com/tshortli
  affiliation: "Apple"
  occupation_title: "Software Engineer"
---
```