### PR TITLE
SignBot: Add signatory 'Ramon Bertran Monfort' (reguilopo)

### DIFF
--- a/_signatures/4mywV0zpmfN9Ig2NckxA1KnWvH93.md
+++ b/_signatures/4mywV0zpmfN9Ig2NckxA1KnWvH93.md
@@ -1,0 +1,6 @@
+---
+  name: "Ramon Bertran Monfort"
+  link: https://twitter.com/reguilopo
+  affiliation: "IBM"
+  occupation_title: "Research Staff Member"
+---


### PR DESCRIPTION
Twitter user: https://twitter.com/reguilopo
Created: 2013-09-16 05:06:21 +0000 UTC, Followers: 175, Following: 612, Tweets: 303, Egg: false

Twitter profile fields:
Name: Ramon Bertran
Website: http://t.co/4iR2tsyjbf
Tagline: RSM at IBM Power and Reliability aware Microarchitectures Group. Tweets/Opinions are my own and do not necessarily reflect IBM values.

Personal page: 

Signature file contents:
```
---
  name: "Ramon Bertran Monfort"
  link: https://twitter.com/reguilopo
  affiliation: "IBM"
  occupation_title: "Research Staff Member"
---
```