### PR TITLE
SignBot: Add signatory 'Nif Ward' (nifty_nif)

### DIFF
--- a/_signatures/klfOAtUWZ6TPh4OfWJAtlCpFYzv1.md
+++ b/_signatures/klfOAtUWZ6TPh4OfWJAtlCpFYzv1.md
@@ -1,0 +1,5 @@
+---
+  name: "Nif Ward"
+  affiliation: "Amazon"
+  occupation_title: "Software Engineer"
+---


### PR DESCRIPTION
Twitter user: https://twitter.com/nifty_nif
Created: 2016-05-04 22:35:00 +0000 UTC, Followers: 28, Following: 93, Tweets: 449, Egg: false

Twitter profile fields:
Name: Nifty Nif
Website: https://t.co/h7X8HEPDoZ
Tagline: Big dumb slimy monster

Personal page: 

Signature file contents:
```
---
  name: "Nif Ward"
  affiliation: "Amazon"
  occupation_title: "Software Engineer"
---
```