### PR TITLE
SignBot: Add signatory 'Wade Armstrong' (kaizendad)

### DIFF
--- a/_signatures/X1maIK2rZ7Yuli0uxuw2mSWrvVU2.md
+++ b/_signatures/X1maIK2rZ7Yuli0uxuw2mSWrvVU2.md
@@ -1,0 +1,5 @@
+---
+  name: "Wade Armstrong"
+  link: https://twitter.com/kaizendad
+  occupation_title: "Principal Engineer"
+---


### PR DESCRIPTION
Twitter user: https://twitter.com/kaizendad
Created: 2009-03-16 20:32:09 +0000 UTC, Followers: 576, Following: 490, Tweets: 3802, Egg: false

Twitter profile fields:
Name: (((Wade Armstrong)))
Website: http://t.co/1lQkCc71mG
Tagline: LA dev type - JS, Node, React, ES 6 & 7 - enjoys, lean/agile, making good things that work. Plenty of Dad content too. Occasionally amusing. Worried.

Personal page: http://kaizendad.com

Signature file contents:
```
---
  name: "Wade Armstrong"
  link: https://twitter.com/kaizendad
  occupation_title: "Principal Engineer"
---
```