### PR TITLE
SignBot: Add signatory 'Andreas Cappell' (cappellmeister)

### DIFF
--- a/_signatures/CfDraikxcTWg8HBWPMkCCnnSH3K2.md
+++ b/_signatures/CfDraikxcTWg8HBWPMkCCnnSH3K2.md
@@ -1,0 +1,6 @@
+---
+  name: "Andreas Cappell"
+  link: https://twitter.com/cappellmeister
+  affiliation: "SinnerSchrader"
+  occupation_title: "Account Director"
+---


### PR DESCRIPTION
Twitter user: https://twitter.com/cappellmeister
Created: 2007-07-04 00:34:02 +0000 UTC, Followers: 2211, Following: 1116, Tweets: 15342, Egg: false

Twitter profile fields:
Name: Andreas Cappell
Website: https://t.co/furfJk4Dgl
Tagline: Account Director @sinnerschrader. Husband to @frauhoelle. Brother of 5. Former werkenntwen, immowelt, Publicis. Opinions expressed are my own, yadda, yadda.

Personal page: https://www.linkedin.com/in/andreascappell/

Signature file contents:
```
---
  name: "Andreas Cappell"
  link: https://twitter.com/cappellmeister
  affiliation: "SinnerSchrader"
  occupation_title: "Account Director"
---
```