### PR TITLE
SignBot: Add signatory 'ओ३म्非龍' (rhymebyter)

### DIFF
--- a/_signatures/Xw27GafvLkhC41IFn4BKAJpLlaz2.md
+++ b/_signatures/Xw27GafvLkhC41IFn4BKAJpLlaz2.md
@@ -1,0 +1,5 @@
+---
+  name: "ओ३म्非龍"
+  affiliation: "w00w00"
+  occupation_title: "「グレェ」"
+---


### PR DESCRIPTION
Twitter user: https://twitter.com/rhymebyter
Created: 2007-09-26 15:50:07 +0000 UTC, Followers: 1338, Following: 2575, Tweets: 84140, Egg: false

Twitter profile fields:
Name: 「グレェ」と言うओ३म्非龍(grey)
Website: https://t.co/zQqQxmZ6iV
Tagline: ♬Other hackers may try to byte your rhymes, but I don't really care if the bits were mine, as long as they can code up some sublime quine.♬

Personal page: twitter.com/rhymebyter

Signature file contents:
```
---
  name: "ओ३म्非龍"
  affiliation: "w00w00"
  occupation_title: "「グレェ」"
---
```