### PR TITLE
SignBot: Add signatory 'Alex Chriss' (acce)

### DIFF
--- a/_signatures/02WpS6L9HgaNGDl3mgEU0aEwD802.md
+++ b/_signatures/02WpS6L9HgaNGDl3mgEU0aEwD802.md
@@ -1,0 +1,5 @@
+---
+  name: "Alex Chriss"
+  link: https://twitter.com/acce
+  affiliation: "Intuit"
+---


### PR DESCRIPTION
Twitter user: https://twitter.com/acce
Created: 2008-03-15 18:18:42 +0000 UTC, Followers: 2487, Following: 978, Tweets: 3224, Egg: false

Twitter profile fields:
Name: Alex Chriss
Website: 
Tagline: VP/GM, Intuit / Entrepreneur / advocate for Small Businesses & the Self-Employed

Personal page: 

Signature file contents:
```
---
  name: "Alex Chriss"
  link: https://twitter.com/acce
  affiliation: "Intuit"
---
```