### PR TITLE
SignBot: Add signatory 'Francis Tseng' (frnsys)

### DIFF
--- a/_signatures/nrId8mpiJ8QiMzoWqJSDPKdAtg52.md
+++ b/_signatures/nrId8mpiJ8QiMzoWqJSDPKdAtg52.md
@@ -1,0 +1,6 @@
+---
+  name: "Francis Tseng"
+  link: https://twitter.com/frnsys
+  affiliation: "Public Science Agency"
+  occupation_title: "Software Engineer"
+---


### PR DESCRIPTION
Twitter user: https://twitter.com/frnsys
Created: 2011-08-13 07:06:15 +0000 UTC, Followers: 2071, Following: 518, Tweets: 4129, Egg: false

Twitter profile fields:
Name: Francis Tseng
Website: https://t.co/XIlfYsiYFQ
Tagline: ( ˘▽˘)っ♨ ~~ design/computers/ai, appropriate the future; now @pub_sci + @NEWINC + https://t.co/9qbxgos9ce, prev @opennews/@coralproject,  @thenewschool, @IDEO

Personal page: 

Signature file contents:
```
---
  name: "Francis Tseng"
  link: https://twitter.com/frnsys
  affiliation: "Public Science Agency"
  occupation_title: "Software Engineer"
---
```