### PR TITLE
SignBot: Add signatory 'Andrew Sliwinski' (thisandagain)

### DIFF
--- a/_signatures/nDcMSEN7MVN7K2V6JDXlj0lpfbu2.md
+++ b/_signatures/nDcMSEN7MVN7K2V6JDXlj0lpfbu2.md
@@ -1,0 +1,6 @@
+---
+  name: "Andrew Sliwinski"
+  link: https://media.mit.edu
+  affiliation: "Massachusetts Institute of Technology"
+  occupation_title: "Research Scientist"
+---


### PR DESCRIPTION
Twitter user: https://twitter.com/thisandagain
Created: 2007-11-27 14:24:50 +0000 UTC, Followers: 1319, Following: 386, Tweets: 5628, Egg: false

Twitter profile fields:
Name: Andrew Sliwinski
Website: https://t.co/EjTANjXoZC
Tagline: Exploring how we play and learn. Research Scientist at MIT @MediaLab. See: @scratch @diy @mozilla

Personal page: http://andrewsliwinski.com

Signature file contents:
```
---
  name: "Andrew Sliwinski"
  link: https://media.mit.edu
  affiliation: "Massachusetts Institute of Technology"
  occupation_title: "Research Scientist"
---
```