### PR TITLE
SignBot: Add signatory 'Yann Hodique' (yann_hodique)

### DIFF
--- a/_signatures/fKGc0I0dQeefvmy6vipOa9NMeq83.md
+++ b/_signatures/fKGc0I0dQeefvmy6vipOa9NMeq83.md
@@ -1,0 +1,6 @@
+---
+  name: "Yann Hodique"
+  link: https://keybase.io/sigma/
+  affiliation: "VMware"
+  occupation_title: "Software Engineer"
+---


### PR DESCRIPTION
Twitter user: https://twitter.com/yann_hodique
Created: 2007-08-20 15:35:28 +0000 UTC, Followers: 78, Following: 37, Tweets: 100, Egg: false

Twitter profile fields:
Name: Yann Hodique
Website: https://t.co/8enReayvMP
Tagline: Coder

Personal page: http://yann.hodique.info

Signature file contents:
```
---
  name: "Yann Hodique"
  link: https://keybase.io/sigma/
  affiliation: "VMware"
  occupation_title: "Software Engineer"
---
```