### PR TITLE
SignBot: Add signatory 'Ethan Heilman' (Ethan_Heilman)

### DIFF
--- a/_signatures/mscufOhUXaXXIWtCDGFPTnWxVyU2.md
+++ b/_signatures/mscufOhUXaXXIWtCDGFPTnWxVyU2.md
@@ -1,0 +1,6 @@
+---
+  name: "Ethan Heilman"
+  link: https://twitter.com/Ethan_Heilman
+  affiliation: "Boston University"
+  occupation_title: "Researcher"
+---


### PR DESCRIPTION
Twitter user: https://twitter.com/Ethan_Heilman
Created: 2012-07-27 18:22:17 +0000 UTC, Followers: 838, Following: 725, Tweets: 6485, Egg: false

Twitter profile fields:
Name: Ethan ✨ Heilman
Website: https://t.co/Cga5vHD4gD
Tagline: Network Security researcher and 'Thrower of strategy verbiage'. 
Project: https://t.co/Fw2OS1lGmW,
Blog: http://t.co/mz3yZURagB

Personal page: EthanHeilman.tumblr.com

Signature file contents:
```
---
  name: "Ethan Heilman"
  link: https://twitter.com/Ethan_Heilman
  affiliation: "Boston University"
  occupation_title: "Researcher"
---
```