### PR TITLE
SignBot: Add signatory 'Thea Holsman' (theawastaken)

### DIFF
--- a/_signatures/h2BvjJHRVPN19Iezk1ktgyFJ0kd2.md
+++ b/_signatures/h2BvjJHRVPN19Iezk1ktgyFJ0kd2.md
@@ -1,0 +1,5 @@
+---
+  name: "Thea Holsman"
+  affiliation: "Adobe Systems"
+  occupation_title: "Technical Architect"
+---


### PR DESCRIPTION
Twitter user: https://twitter.com/theawastaken
Created: 2007-12-12 22:14:58 +0000 UTC, Followers: 203, Following: 271, Tweets: 2456, Egg: false

Twitter profile fields:
Name: thea
Website: 
Tagline: nerd.

Personal page: 

Signature file contents:
```
---
  name: "Thea Holsman"
  affiliation: "Adobe Systems"
  occupation_title: "Technical Architect"
---
```