### PR TITLE
SignBot: Add signatory 'Evan Walsh' (evanwalsh)

### DIFF
--- a/_signatures/7Qve81D03MVbPsj3tQQS0FvNIZ93.md
+++ b/_signatures/7Qve81D03MVbPsj3tQQS0FvNIZ93.md
@@ -1,0 +1,6 @@
+---
+  name: "Evan Walsh"
+  link: http://www.evanwalsh.net/
+  affiliation: "Harvest"
+  occupation_title: "Developer"
+---


### PR DESCRIPTION
Twitter user: https://twitter.com/evanwalsh
Created: 2007-03-20 23:13:48 +0000 UTC, Followers: 424, Following: 296, Tweets: 3425, Egg: false

Twitter profile fields:
Name: Evan Walsh
Website: https://t.co/HR4vLi7QA7
Tagline: `@Skylar__Walsh’s husband. Creator of @neonsolitude. For all of my virtue, why can I not hold the truth?`

Personal page: http://www.evanwalsh.net/

Signature file contents:
```
---
  name: "Evan Walsh"
  link: http://www.evanwalsh.net/
  affiliation: "Harvest"
  occupation_title: "Developer"
---
```