### PR TITLE
SignBot: Add signatory 'Andreas Hunn' (andyhunn)

### DIFF
--- a/_signatures/p9FgseOohvOk3KpgHs3GJBgZHHC3.md
+++ b/_signatures/p9FgseOohvOk3KpgHs3GJBgZHHC3.md
@@ -1,0 +1,6 @@
+---
+  name: "Andreas Hunn"
+  link: https://twitter.com/andyhunn
+  affiliation: "Resonate"
+  occupation_title: "Co-Founder & COO"
+---


### PR DESCRIPTION
Twitter user: https://twitter.com/andyhunn
Created: 2009-07-11 14:26:40 +0000 UTC, Followers: 426, Following: 527, Tweets: 885, Egg: false

Twitter profile fields:
Name: Andy Hunn
Website: 
Tagline: `Startup Veteran. Co-Founder/COO at Resonate. Cardiac arrest survivor. Passions - family, startups, tech, fly fishing, the West. Religion: Liverpool FC.`

Personal page: http://linkedin.com/in/andy-hunn-5a0288

Signature file contents:
```
---
  name: "Andreas Hunn"
  link: https://twitter.com/andyhunn
  affiliation: "Resonate"
  occupation_title: "Co-Founder & COO"
---
```