### PR TITLE
SignBot: Add signatory 'Richard Magahiz' (richmagahiz)

### DIFF
--- a/_signatures/Yv7jzDbKd6PZpSHDWNvvAW0I4cO2.md
+++ b/_signatures/Yv7jzDbKd6PZpSHDWNvvAW0I4cO2.md
@@ -1,0 +1,6 @@
+---
+  name: "Richard Magahiz"
+  link: https://twitter.com/richmagahiz
+  affiliation: "DAQRI"
+  occupation_title: "Devops Engineer"
+---


### PR DESCRIPTION
Twitter user: https://twitter.com/richmagahiz
Created: 2010-05-17 20:55:33 +0000 UTC, Followers: 293, Following: 141, Tweets: 24278, Egg: false

Twitter profile fields:
Name: Unicorn Surprise
Website: http://t.co/qhtQ8fVDRT
Tagline: `On the horn of a monolemma`

Personal page: http://frabjoustimes.magahiz.com/pages/social

Signature file contents:
```
---
  name: "Richard Magahiz"
  link: https://twitter.com/richmagahiz
  affiliation: "DAQRI"
  occupation_title: "Devops Engineer"
---
```