### PR TITLE
SignBot: Add signatory 'Ryan Miron' (ryanisfluffy)

### DIFF
--- a/_signatures/DWnT5Sjch9hM8oJYip1M0Bosl693.md
+++ b/_signatures/DWnT5Sjch9hM8oJYip1M0Bosl693.md
@@ -1,0 +1,6 @@
+---
+  name: "Ryan Miron"
+  link: https://twitter.com/ryanisfluffy
+  affiliation: "Elsevier"
+  occupation_title: "Software Engineer"
+---


### PR DESCRIPTION
Twitter user: https://twitter.com/ryanisfluffy
Created: 2010-04-10 01:13:03 +0000 UTC, Followers: 81, Following: 129, Tweets: 1103, Egg: false

Twitter profile fields:
Name: Ryan Miron
Website: 
Tagline: `Software Engineer, originally from Buffalo, NY. I love going to shows, documentaries, science, and learning.`

Personal page: 

Signature file contents:
```
---
  name: "Ryan Miron"
  link: https://twitter.com/ryanisfluffy
  affiliation: "Elsevier"
  occupation_title: "Software Engineer"
---
```