### PR TITLE
SignBot: Add signatory 'Alexis Deveria' (Fyrd)

### DIFF
--- a/_signatures/GgonG7SH5AQZpG528q9Bcz6NInt1.md
+++ b/_signatures/GgonG7SH5AQZpG528q9Bcz6NInt1.md
@@ -1,0 +1,6 @@
+---
+  name: "Alexis Deveria"
+  link: https://twitter.com/Fyrd
+  affiliation: "Adobe"
+  occupation_title: "Software engineer"
+---


### PR DESCRIPTION
Twitter user: https://twitter.com/Fyrd
Created: 2007-09-17 16:38:01 +0000 UTC, Followers: 2588, Following: 309, Tweets: 3756, Egg: false

Twitter profile fields:
Name: Alexis Deveria
Website: http://t.co/jcFbZp51ff
Tagline: `Web tinkerer, Adobian, http://t.co/k1q9jlSJlK guy.`

Personal page: http://a.deveria.com

Signature file contents:
```
---
  name: "Alexis Deveria"
  link: https://twitter.com/Fyrd
  affiliation: "Adobe"
  occupation_title: "Software engineer"
---
```