### PR TITLE
SignBot: Add signatory 'joshua stein' (jcs)

### DIFF
--- a/_signatures/j0qoQT60Q5hooDgltrB5gLUE1dn2.md
+++ b/_signatures/j0qoQT60Q5hooDgltrB5gLUE1dn2.md
@@ -1,0 +1,6 @@
+---
+  name: "joshua stein"
+  link: https://jcs.org/
+  affiliation: "Superblock"
+  occupation_title: "Owner"
+---


### PR DESCRIPTION
Twitter user: https://twitter.com/jcs
Created: 2008-11-07 21:30:19 +0000 UTC, Followers: 1074, Following: 81, Tweets: 1553, Egg: false

Twitter profile fields:
Name: joshua stein
Website: https://t.co/Kd59RnNqRt
Tagline: `we are friends, hello. i make pushover as @superblock, i am an @openbsd developer, i created @lobsters, and i podcast on @garbagefm.`

Personal page: https://jcs.org/

Signature file contents:
```
---
  name: "joshua stein"
  link: https://jcs.org/
  affiliation: "Superblock"
  occupation_title: "Owner"
---
```