### PR TITLE
SignBot: Add signatory 'Frederic Jean' (fredjean)

### DIFF
--- a/_signatures/d9Xj7qjqOLcjnGuydomB52RpRom2.md
+++ b/_signatures/d9Xj7qjqOLcjnGuydomB52RpRom2.md
@@ -1,6 +1,6 @@
 ---
   name: "Frederic Jean"
-  link: HTTPS://fredjean.net
+  link: https://fredjean.net
   affiliation: "The Walt Disney Studios"
-  occupation_title: "SR. Staff Software Engineer"
+  occupation_title: "Sr. Staff Software Engineer"
 ---

--- a/_signatures/d9Xj7qjqOLcjnGuydomB52RpRom2.md
+++ b/_signatures/d9Xj7qjqOLcjnGuydomB52RpRom2.md
@@ -1,0 +1,6 @@
+---
+  name: "Frederic Jean"
+  link: HTTPS://fredjean.net
+  affiliation: "The Walt Disney Studios"
+  occupation_title: "SR. Staff Software Engineer"
+---


### PR DESCRIPTION
Twitter user: https://twitter.com/fredjean
Created: 2006-11-15 18:36:19 +0000 UTC, Followers: 626, Following: 815, Tweets: 15376, Egg: false

Twitter profile fields:
Name: That Fred.
Website: https://t.co/dSrBNY8Ozy
Tagline: `I make the bits flow...`

Personal page: HTTPS://fredjean.net

Signature file contents:
```
---
  name: "Frederic Jean"
  link: HTTPS://fredjean.net
  affiliation: "The Walt Disney Studios"
  occupation_title: "SR. Staff Software Engineer"
---
```