### PR TITLE
SignBot: Add signatory 'Mark Masterson' (mastermark)

### DIFF
--- a/_signatures/p6njvAGOWUWpRUJDojlh3wwaVAg1.md
+++ b/_signatures/p6njvAGOWUWpRUJDojlh3wwaVAg1.md
@@ -1,0 +1,5 @@
+---
+  name: "Mark Masterson"
+  link: https://twitter.com/mastermark
+  affiliation: "Google"
+---


### PR DESCRIPTION
Twitter user: https://twitter.com/mastermark
Created: 2007-06-09 16:13:15 +0000 UTC, Followers: 2266, Following: 953, Tweets: 7222, Egg: false

Twitter profile fields:
Name: Mark Masterson
Website: https://t.co/FmIyBG8NX9
Tagline: `Heads up startup DevRel for Google in Europe. Also adoring partner of @pokeysusie, lesscode architect of thoughtstuff, and less clever than he thinks he is.`

Personal page: https://uk.linkedin.com/in/markmasterson

Signature file contents:
```
---
  name: "Mark Masterson"
  link: https://twitter.com/mastermark
  affiliation: "Google"
---
```