### PR TITLE
SignBot: Add signatory 'Mike Stop Continues' (stopcontinues)

### DIFF
--- a/_signatures/wJkkouuZnFPJg3WqDpXMoR8TkGo2.md
+++ b/_signatures/wJkkouuZnFPJg3WqDpXMoR8TkGo2.md
@@ -1,0 +1,6 @@
+---
+  name: "Mike Stop Continues"
+  link: https://mikestopcontinues.com
+  organization: "The Huffington Post"
+  occupation_title: "Principal Software Engineer"
+---


### PR DESCRIPTION
Twitter user: [https://twitter.com/stopcontinues](https://twitter.com/stopcontinues)
Created: 2008-03-20 20:43:58 +0000 UTC, Followers: 715, Following: 108, Tweets: 397, Egg: false

Twitter profile fields:
Name: Mike Stop Continues
Website: http://t.co/hEngppbWFu
Tagline: `Not more than your average genius—I don't think.`

Personal page: https://mikestopcontinues.com
Organization description: Digital journalism
Organization country: United States

Signature file contents:
```
---
  name: "Mike Stop Continues"
  link: https://mikestopcontinues.com
  organization: "The Huffington Post"
  occupation_title: "Principal Software Engineer"
---
```