### PR TITLE
SignBot: Add signatory 'Steve Calderon' (Vespa59)

### DIFF
--- a/_signatures/DeSTuElt7SYJG0clzGHhDbw97V82.md
+++ b/_signatures/DeSTuElt7SYJG0clzGHhDbw97V82.md
@@ -1,0 +1,6 @@
+---
+  name: "Steve Calderon"
+  link: https://twitter.com/Vespa59
+  organization: "Fastly"
+  occupation_title: "Director of User Experience"
+---


### PR DESCRIPTION
Twitter user: [https://twitter.com/Vespa59](https://twitter.com/Vespa59)
Created: 2007-03-30 02:15:47 +0000 UTC, Followers: 718, Following: 381, Tweets: 4980, Egg: false

Twitter profile fields:
Name: Steve
Website: http://t.co/mgDoqhFyZl
Tagline: `The sportos, the motorheads, geeks, sluts, bloods, wastoids, dweebies, dickheads - they all adore him. They think he's a righteous dude.`

Personal page: http://www.stevecalderon.com/
Organization description: Make the internet fast and robust
Organization country: United States

Signature file contents:
```
---
  name: "Steve Calderon"
  link: https://twitter.com/Vespa59
  organization: "Fastly"
  occupation_title: "Director of User Experience"
---
```