### PR TITLE
SignBot: Add signatory 'Gary Leatherman' (gManiPhone)

### DIFF
--- a/_signatures/H6LvB3dEvsMWJ2y2DTvDbQ61CPF3.md
+++ b/_signatures/H6LvB3dEvsMWJ2y2DTvDbQ61CPF3.md
@@ -1,0 +1,6 @@
+---
+  name: "Gary Leatherman"
+  link: https://twitter.com/gManiPhone
+  organization: "macMonkey Digital Studios"
+  occupation_title: "Digital Producer"
+---


### PR DESCRIPTION
Twitter user: [https://twitter.com/gManiPhone](https://twitter.com/gManiPhone)
Created: 2007-05-20 03:07:43 +0000 UTC, Followers: 694, Following: 1430, Tweets: 4597, Egg: false

Twitter profile fields:
Name: Gary Leatherman
Website: https://t.co/WpluCvzuuC
Tagline: `TV Producer, Mac Guy, Science Geek. Also a Maker via Education Reformer via Free Play & Kids Advocate. DAMN!`

Personal page: macmonkey.tv
Organization description: produces digital interactives
Organization country: United States

Signature file contents:
```
---
  name: "Gary Leatherman"
  link: https://twitter.com/gManiPhone
  organization: "macMonkey Digital Studios"
  occupation_title: "Digital Producer"
---
```