### PR TITLE
SignBot: Add signatory 'Cathy Hindersinn' (chindersinn)

### DIFF
--- a/_signatures/YfQvIxbUj5TA9BrU34afs9gZwpG2.md
+++ b/_signatures/YfQvIxbUj5TA9BrU34afs9gZwpG2.md
@@ -1,0 +1,6 @@
+---
+  name: "Cathy Hindersinn"
+  link: https://twitter.com/chindersinn
+  organization: "Google"
+  occupation_title: "SWE"
+---


### PR DESCRIPTION
Twitter user: [https://twitter.com/chindersinn](https://twitter.com/chindersinn)
Created: 2009-07-21 20:14:55 +0000 UTC, Followers: 173, Following: 184, Tweets: 3829, Egg: false

Twitter profile fields:
Name: Fauxlivia Pope
Website: https://t.co/T3W4d98iDq
Tagline: `she/they. Software engineer, SFF fan, feminist, polymath, overthinker, fat activist, parent, SJW. 2016 candidate for That's 'Ms. Annoying Feminist' To You.`

Personal page: https://www.linkedin.com/in/catherine-hindersinn-0924609?trk=hp-identity-photo
Organization description: Privacy & Security
Organization country: US

Signature file contents:
```
---
  name: "Cathy Hindersinn"
  link: https://twitter.com/chindersinn
  organization: "Google"
  occupation_title: "SWE"
---
```