### PR TITLE
SignBot: Add signatory 'Aldric Giacomoni' (Trevoke)

### DIFF
--- a/_signatures/gt1VW19XGFUiLo3WD4sjTHzSvNp1.md
+++ b/_signatures/gt1VW19XGFUiLo3WD4sjTHzSvNp1.md
@@ -1,0 +1,6 @@
+---
+  name: "Aldric Giacomoni"
+  link: blog.trevoke.net
+  organization: "N/A"
+  occupation_title: "Software Developer"
+---


### PR DESCRIPTION
Twitter user: [https://twitter.com/Trevoke](https://twitter.com/Trevoke)
Created: 2009-03-06 04:22:16 +0000 UTC, Followers: 436, Following: 265, Tweets: 8929, Egg: false

Twitter profile fields:
Name: Aldric
Website: http://t.co/oHDBN2Gyza
Tagline: `Martial arts, Ruby, go/weiqi player. All views and idiocy are my own, all wisdom and genius can be traced back to my interactions with someone else.`

Personal page: https://keybase.io/trevoke
Organization description: N/A
Organization country: United States

Signature file contents:
```
---
  name: "Aldric Giacomoni"
  link: blog.trevoke.net
  organization: "N/A"
  occupation_title: "Software Developer"
---
```