### PR TITLE
SignBot: Add signatory 'Ian Bartholomew' (iandotjpg)

### DIFF
--- a/_signatures/Q6LkHmhsmIg0qJenUCKCGteQkqx2.md
+++ b/_signatures/Q6LkHmhsmIg0qJenUCKCGteQkqx2.md
@@ -1,0 +1,6 @@
+---
+  name: "Ian Bartholomew"
+  link: https://twitter.com/iandotjpg
+  organization: "Huge"
+  occupation_title: "Technical Architect "
+---


### PR DESCRIPTION
Twitter user: [https://twitter.com/iandotjpg](https://twitter.com/iandotjpg)
Created: 2008-11-27 20:43:36 +0000 UTC, Followers: 144, Following: 389, Tweets: 7546, Egg: false

Twitter profile fields:
Name: ☠ Ian ☠
Website: http://t.co/A65kLIFGuA
Tagline: `I came here to do two things: kick ass and chew bubble gum, and I'm all out of bubble gum`

Personal page: http://www.ianbartholomew.com
Organization description: US based digital design company
Organization country: US

Signature file contents:
```
---
  name: "Ian Bartholomew"
  link: https://twitter.com/iandotjpg
  organization: "Huge"
  occupation_title: "Technical Architect "
---
```