### PR TITLE
SignBot: Add signatory 'Ryan McKern' (the_mckern)

### DIFF
--- a/_signatures/VlDqfwtYetYaL5gO1ewTN955Tqk1.md
+++ b/_signatures/VlDqfwtYetYaL5gO1ewTN955Tqk1.md
@@ -1,0 +1,6 @@
+---
+  name: "Ryan McKern"
+  link: https://twitter.com/the_mckern
+  organization: "Puppet, inc."
+  occupation_title: "Release Engineer"
+---


### PR DESCRIPTION
Twitter user: [https://twitter.com/the_mckern](https://twitter.com/the_mckern)
Created: 2011-03-26 04:28:27 +0000 UTC, Followers: 337, Following: 331, Tweets: 24300, Egg: false

Twitter profile fields:
Name: Ryan McKern
Website: https://t.co/vhu8M0AlT8
Tagline: `Begrudging Rubyist, Prescriptive Descriptivist.`

Personal page: 
Organization description: 
Organization country: United States

Signature file contents:
```
---
  name: "Ryan McKern"
  link: https://twitter.com/the_mckern
  organization: "Puppet, inc."
  occupation_title: "Release Engineer"
---
```