### PR TITLE
SignBot: Add signatory 'James Governor' (monkchips)

### DIFF
--- a/_signatures/tBjpuSRN1dRpihnBseq7sKDm3km2.md
+++ b/_signatures/tBjpuSRN1dRpihnBseq7sKDm3km2.md
@@ -1,0 +1,6 @@
+---
+  name: "James Governor"
+  link: http://redmonk.com/
+  organization: "RedMonk"
+  occupation_title: "founder"
+---


### PR DESCRIPTION
Twitter user: [https://twitter.com/monkchips](https://twitter.com/monkchips)
Created: 2006-12-12 17:35:55 +0000 UTC, Followers: 21476, Following: 3786, Tweets: 97280, Egg: false

Twitter profile fields:
Name: Ike Anteven
Website: http://t.co/4rH6XD51qB
Tagline: `redmonk co-founder, optimist, developer advocate, progressive, occasionally rebellious`

Personal page: http://redmonk.com/jgovernor/
Organization description: industry analyst company
Organization country: United Kingdom

Signature file contents:
```
---
  name: "James Governor"
  link: http://redmonk.com/
  organization: "RedMonk"
  occupation_title: "founder"
---
```