### PR TITLE
SignBot: Add signatory 'Rand Fishkin' (randfish)

### DIFF
--- a/_signatures/vCaByz6FlOUy6BYCU4NDnrPmXtJ2.md
+++ b/_signatures/vCaByz6FlOUy6BYCU4NDnrPmXtJ2.md
@@ -1,0 +1,6 @@
+---
+  name: "Rand Fishkin"
+  link: Https://moz.com/rand 
+  organization: "Moz"
+  occupation_title: "Founder "
+---


### PR DESCRIPTION
Twitter user: [https://twitter.com/randfish](https://twitter.com/randfish)
Created: 2007-06-02 19:28:10 +0000 UTC, Followers: 352142, Following: 150, Tweets: 37543, Egg: false

Twitter profile fields:
Name: Rand Fishkin
Website: http://t.co/5epTIbgxbq
Tagline: `Moz founder, author, blogger, husband to @everywhereist, tiny Techstars investor, & feminist. I tweet 30-40X/week about marketing, SEO, technology, & startups.`

Personal page: Https://moz.com/rand
Organization description: Moz makes software to help professional marketers with SEO 
Organization country: United States 

Signature file contents:
```
---
  name: "Rand Fishkin"
  link: Https://moz.com/rand 
  organization: "Moz"
  occupation_title: "Founder "
---
```