### PR TITLE
SignBot: Add signatory 'John Doherty' (dohertyjf)

### DIFF
--- a/_signatures/nrNzXXzzYQZP9RW1jOU40zSgKvw2.md
+++ b/_signatures/nrNzXXzzYQZP9RW1jOU40zSgKvw2.md
@@ -1,0 +1,6 @@
+---
+  name: "John Doherty"
+  link: https://twitter.com/dohertyjf
+  organization: "Credo"
+  occupation_title: "Founder"
+---


### PR DESCRIPTION
Twitter user: [https://twitter.com/dohertyjf](https://twitter.com/dohertyjf)
Created: 2008-11-24 01:45:11 +0000 UTC, Followers: 24187, Following: 499, Tweets: 58663, Egg: false

Twitter profile fields:
Name: John Doherty
Website: https://t.co/aLuR5hGoda
Tagline: `Founder of @getcredo. Growth marketer. @distilled/@zillow/@hotpads alum. Speaker. Husband. Kingdom follower. Caffeinated ENTJ. Black lab owner. ¯\_(ツ)_/¯`

Personal page: http://www.johnfdoherty.com
Organization description: Digital marketing marketplace
Organization country: USA

Signature file contents:
```
---
  name: "John Doherty"
  link: https://twitter.com/dohertyjf
  organization: "Credo"
  occupation_title: "Founder"
---
```