### PR TITLE
SignBot: Add signatory 'Stephen O'Grady' (sogrady)

### DIFF
--- a/_signatures/mE7UIAbp2Hdi3DAazeIQ1LYLk9h2.md
+++ b/_signatures/mE7UIAbp2Hdi3DAazeIQ1LYLk9h2.md
@@ -1,0 +1,6 @@
+---
+  name: "Stephen O'Grady"
+  link: https://twitter.com/sogrady
+  organization: "RedMonk"
+  occupation_title: "Principal Analyst"
+---


### PR DESCRIPTION
Twitter user: [https://twitter.com/sogrady](https://twitter.com/sogrady)
Created: 2006-12-22 01:53:11 +0000 UTC, Followers: 7994, Following: 635, Tweets: 46878, Egg: false

Twitter profile fields:
Name: steve o'grady
Website: http://t.co/NlsofJ8aQb
Tagline: `i helped found RedMonk. if you see someone at a tech conference wearing a Red Sox hat, that's probably me. wrote @newkingmakers. married to @girltuesday. eph.`

Personal page: https://keybase.io/sogrady
Organization description: Industry analyst company
Organization country: United States

Signature file contents:
```
---
  name: "Stephen O'Grady"
  link: https://twitter.com/sogrady
  organization: "RedMonk"
  occupation_title: "Principal Analyst"
---
```