### PR TITLE
SignBot: Add signatory 'Ryan MacCarrigan' (RyanMacCarrigan)

### DIFF
--- a/_signatures/feY51EFXRSOUvFwxXFjJGhZoDGe2.md
+++ b/_signatures/feY51EFXRSOUvFwxXFjJGhZoDGe2.md
@@ -1,0 +1,6 @@
+---
+  name: "Ryan MacCarrigan"
+  link: https://twitter.com/RyanMacCarrigan
+  organization: "LeanStudio"
+  occupation_title: "Founder"
+---


### PR DESCRIPTION
Twitter user: [https://twitter.com/RyanMacCarrigan](https://twitter.com/RyanMacCarrigan)
Created: 2008-11-06 02:47:46 +0000 UTC, Followers: 3275, Following: 620, Tweets: 1980, Egg: false

Twitter profile fields:
Name: Ryan MacCarrigan
Website: http://t.co/gjbv6Quu05
Tagline: `Insatiably curious about the world | Destroyer of confirmation bias & pseudoscience | Ex astris, scientia | Founder @LeanStudio | #LeanStartup #DesignThinking`

Personal page: https://www.linkedin.com/in/ryanmaccarrigan
Organization description: Product Design
Organization country: United States

Signature file contents:
```
---
  name: "Ryan MacCarrigan"
  link: https://twitter.com/RyanMacCarrigan
  organization: "LeanStudio"
  occupation_title: "Founder"
---
```