### PR TITLE
SignBot: Add signatory 'Patrick Ellis' (pje_txt)

### DIFF
--- a/_signatures/RWXf9cL3WrQVdV91PxBZEIIfLOB3.md
+++ b/_signatures/RWXf9cL3WrQVdV91PxBZEIIfLOB3.md
@@ -1,0 +1,5 @@
+---
+  name: "Patrick Ellis"
+  organization: "SoundCloud"
+  occupation_title: "Engineer"
+---


### PR DESCRIPTION
Twitter user: [https://twitter.com/pje_txt](https://twitter.com/pje_txt)
Created: 2010-01-17 07:07:50 +0000 UTC, Followers: 226, Following: 305, Tweets: 1465, Egg: false

Twitter profile fields:
Name: pje.txt
Website: https://t.co/NnAsPNnDtL
Tagline: `Q-Bert IRL`

Personal page: https://soundcloud.com
Organization description: 
Organization country: United States

Signature file contents:
```
---
  name: "Patrick Ellis"
  organization: "SoundCloud"
  occupation_title: "Engineer"
---
```