### PR TITLE
SignBot: Add signatory 'Andrew Rifken' (arifken)

### DIFF
--- a/_signatures/HlKcdukyFPUUaYsg7M84ctGp7l93.md
+++ b/_signatures/HlKcdukyFPUUaYsg7M84ctGp7l93.md
@@ -1,0 +1,5 @@
+---
+  name: "Andrew Rifken"
+  link: https://twitter.com/arifken
+  occupation_title: "Software Engineer"
+---


### PR DESCRIPTION
Twitter user: [https://twitter.com/arifken](https://twitter.com/arifken)
Created: 2009-05-21 00:28:36 +0000 UTC, Followers: 56, Following: 35, Tweets: 266, Egg: false

Twitter profile fields:
Name: Andy Rifken
Website: 
Tagline: ``

Personal page: 
Organization description: 
Organization country: 

Signature file contents:
```
---
  name: "Andrew Rifken"
  link: https://twitter.com/arifken
  occupation_title: "Software Engineer"
---
```