### PR TITLE
SignBot: Add signatory 'Juan Herrera' (jchera)

### DIFF
--- a/_signatures/nPDjL8710peVi6yGWPqkUMaWa692.md
+++ b/_signatures/nPDjL8710peVi6yGWPqkUMaWa692.md
@@ -1,0 +1,6 @@
+---
+  name: "Juan Herrera"
+  link: https://twitter.com/jchera
+  organization: "Columbia Sportswear"
+  occupation_title: "Systems Engineer"
+---


### PR DESCRIPTION
Twitter user: [https://twitter.com/jchera](https://twitter.com/jchera)
Created: 2008-12-22 05:22:18 +0000 UTC, Followers: 15, Following: 83, Tweets: 55, Egg: false

Twitter profile fields:
Name: Juan Herrera
Website: 
Tagline: `Brain retooling and loving it..! I am BrainDev'ed...`

Personal page: 
Organization description: Retail
Organization country: USA

Signature file contents:
```
---
  name: "Juan Herrera"
  link: https://twitter.com/jchera
  organization: "Columbia Sportswear"
  occupation_title: "Systems Engineer"
---
```