### PR TITLE
SignBot: Add signatory 'Rich Burroughs' (richburroughs)

### DIFF
--- a/_signatures/Zn1CtAX1JSg5Hp2iWccN8egdCYl2.md
+++ b/_signatures/Zn1CtAX1JSg5Hp2iWccN8egdCYl2.md
@@ -1,0 +1,6 @@
+---
+  name: "Rich Burroughs"
+  link: https://twitter.com/richburroughs
+  organization: "Puppet"
+  occupation_title: "SRE"
+---


### PR DESCRIPTION
Twitter user: [https://twitter.com/richburroughs](https://twitter.com/richburroughs)
Created: 2009-01-26 19:35:35 +0000 UTC, Followers: 3722, Following: 651, Tweets: 84652, Egg: false

Twitter profile fields:
Name: Rich Burroughs
Website: https://t.co/CNNWdOquGJ
Tagline: `SRE at @puppetize, organizer @DevOpsDaysPDX, art photographer, smartass. Opinions are mine.`

Personal page: https://keybase.io/richburroughs
Organization description: Automation software
Organization country: US

Signature file contents:
```
---
  name: "Rich Burroughs"
  link: https://twitter.com/richburroughs
  organization: "Puppet"
  occupation_title: "SRE"
---
```