### PR TITLE
SignBot: Add signatory 'Dan Fabulich' (dfabu)

### DIFF
--- a/_signatures/zm8DX3JUWDUMMcxk8bFwOglkLdr2.md
+++ b/_signatures/zm8DX3JUWDUMMcxk8bFwOglkLdr2.md
@@ -1,0 +1,6 @@
+---
+  name: "Dan Fabulich"
+  link: https://twitter.com/dfabu
+  organization: "Redfin"
+  occupation_title: "Software Engineer"
+---


### PR DESCRIPTION
Twitter user: [https://twitter.com/dfabu](https://twitter.com/dfabu)
Created: 2007-05-24 19:08:47 +0000 UTC, Followers: 605, Following: 368, Tweets: 3726, Egg: false

Twitter profile fields:
Name: Dan Fabulich
Website: https://t.co/j1bZAZQHkh
Tagline: `I work at @choiceofgames and @redfin; I run the @sfbayifgroup`

Personal page: http://linkedin.com/in/dan-fabulich-5693b21
Organization description: Real estate
Organization country: US

Signature file contents:
```
---
  name: "Dan Fabulich"
  link: https://twitter.com/dfabu
  organization: "Redfin"
  occupation_title: "Software Engineer"
---
```