### PR TITLE
SignBot: Add signatory 'Daniel Blumenthal' (DanCast)

### DIFF
--- a/_signatures/pKx0QNFVNoc5vAvm10m58IlZqwC3.md
+++ b/_signatures/pKx0QNFVNoc5vAvm10m58IlZqwC3.md
@@ -1,0 +1,5 @@
+---
+  name: "Daniel Blumenthal"
+  link: https://twitter.com/DanCast
+  organization: "TripAdvisor"
+---


### PR DESCRIPTION
Twitter user: [https://twitter.com/DanCast](https://twitter.com/DanCast)
Created: 2010-05-01 12:44:23 +0000 UTC, Followers: 417, Following: 178, Tweets: 4225, Egg: false

Twitter profile fields:
Name: Daniel Blumenthal
Website: http://t.co/i2GdvNYnHd
Tagline: `Wistful foodie, proud father, unrepentent nerd. #HeForShe`

Personal page: https://keybase.io/danielblumenthal
Organization description: Travel web site
Organization country: USA

Signature file contents:
```
---
  name: "Daniel Blumenthal"
  link: https://twitter.com/DanCast
  organization: "TripAdvisor"
---
```