### PR TITLE
SignBot: Add signatory 'Leo Franchi' (lfranchi)

### DIFF
--- a/_signatures/sVFTXOay51RNuOigVEEOws2Xztd2.md
+++ b/_signatures/sVFTXOay51RNuOigVEEOws2Xztd2.md
@@ -1,0 +1,5 @@
+---
+  name: "Leo Franchi"
+  link: https://twitter.com/lfranchi
+  occupation_title: "Software Engineer"
+---


### PR DESCRIPTION
Twitter user: [https://twitter.com/lfranchi](https://twitter.com/lfranchi)
Created: 2007-07-27 16:11:59 +0000 UTC, Followers: 662, Following: 462, Tweets: 4473, Egg: false

Twitter profile fields:
Name: leo franchi
Website: http://t.co/lvHhBwT74X
Tagline: `still tangling with old man gravity.

proud alumnus of @recursecenter. !!Con & never graduate.

feminist.`

Personal page: https://keybase.io/lfranchi
Organization description: 
Organization country: 

Signature file contents:
```
---
  name: "Leo Franchi"
  link: https://twitter.com/lfranchi
  occupation_title: "Software Engineer"
---
```