### PR TITLE
SignBot: Add signatory 'Shawn Ferry' (shawnferry)

### DIFF
--- a/_signatures/uhvZ5Bc1R8bqfBzcoy71XDrifQU2.md
+++ b/_signatures/uhvZ5Bc1R8bqfBzcoy71XDrifQU2.md
@@ -1,6 +1,6 @@
 ---
   name: "Shawn Ferry"
-  link: shawnferry.com
+  link: http://shawnferry.com
   organization: "Oracle"
-  occupation_title: "Sr Principle Software Engineer"
+  occupation_title: "Sr. Principal Software Engineer"
 ---

--- a/_signatures/uhvZ5Bc1R8bqfBzcoy71XDrifQU2.md
+++ b/_signatures/uhvZ5Bc1R8bqfBzcoy71XDrifQU2.md
@@ -1,0 +1,6 @@
+---
+  name: "Shawn Ferry"
+  link: shawnferry.com
+  organization: "Oracle"
+  occupation_title: "Sr Principle Software Engineer"
+---


### PR DESCRIPTION
Twitter user: [https://twitter.com/shawnferry](https://twitter.com/shawnferry)
Created: 2007-01-22 21:32:25 +0000 UTC, Followers: 398, Following: 330, Tweets: 16367, Egg: false

Twitter profile fields:
Name: HaphazardShuttlecock
Website: https://t.co/CDldDYSwRX
Tagline: `Almost exactly what you might expect; except when it isn't. Also: Better than new shoes.`

Personal page: https://github.com/shawnferry
Organization description: Damn near everything
Organization country: USA

Signature file contents:
```
---
  name: "Shawn Ferry"
  link: shawnferry.com
  organization: "Oracle"
  occupation_title: "Sr Principle Software Engineer"
---
```