### PR TITLE
SignBot: Add signatory 'Art Gillespie' (artgillespie)

### DIFF
--- a/_signatures/HuN0Km2n0JgcL7ehEtHhFmAN1032.md
+++ b/_signatures/HuN0Km2n0JgcL7ehEtHhFmAN1032.md
@@ -1,0 +1,5 @@
+---
+  name: "Art Gillespie"
+  link: https://twitter.com/artgillespie
+  occupation_title: "Software Engineer"
+---


### PR DESCRIPTION
Twitter user: [https://twitter.com/artgillespie](https://twitter.com/artgillespie)
Created: 2008-01-10 21:09:14 +0000 UTC, Followers: 1095, Following: 526, Tweets: 14819, Egg: false

Twitter profile fields:
Name: Art Gillespie
Website: https://t.co/uLqL5dak80
Tagline: `Dad. Cyclist. Engineer.`

Personal page: https://keybase.io/artgillespie
Organization description: 
Organization country: 

Signature file contents:
```
---
  name: "Art Gillespie"
  link: https://twitter.com/artgillespie
  occupation_title: "Software Engineer"
---
```