### PR TITLE
SignBot: Add signatory 'Meighan Rasley' (knaydee)

### DIFF
--- a/_signatures/klA2WPVub4XGhXHYkI1HAcfiRSi2.md
+++ b/_signatures/klA2WPVub4XGhXHYkI1HAcfiRSi2.md
@@ -1,0 +1,6 @@
+---
+  name: "Meighan Rasley"
+  link: https://www.linkedin.com/in/meighan-rasley-315a2610b
+  organization: "Dell EMC"
+  occupation_title: "Associate Software Engineer"
+---


### PR DESCRIPTION
Twitter user: [https://twitter.com/knaydee](https://twitter.com/knaydee)
Created: 2015-06-09 22:16:29 +0000 UTC, Followers: 142, Following: 261, Tweets: 129, Egg: false

Twitter profile fields:
Name: Meighan
Website: 
Tagline: `@adaacademy cohort[3], Fiona's human`

Personal page: https://www.linkedin.com/in/meighan-rasley-315a2610b
Organization description: Data storage - hardware/software
Organization country: United States

Signature file contents:
```
---
  name: "Meighan Rasley"
  link: https://www.linkedin.com/in/meighan-rasley-315a2610b
  organization: "Dell EMC"
  occupation_title: "Associate Software Engineer"
---
```