### PR TITLE
SignBot: Add signatory 'Aaron Patterson' (tenderlove)

### DIFF
--- a/_signatures/I0G3S00BfFVkiGxFgISYRCrvcHJ3.md
+++ b/_signatures/I0G3S00BfFVkiGxFgISYRCrvcHJ3.md
@@ -1,0 +1,6 @@
+---
+  name: "Aaron Patterson"
+  link: https://twitter.com/tenderlove
+  organization: "GitHub"
+  occupation_title: "Systems Engineer"
+---


### PR DESCRIPTION
Twitter user: [https://twitter.com/tenderlove](https://twitter.com/tenderlove)
Created: 2008-05-13 17:25:31 +0000 UTC, Followers: 35239, Following: 664, Tweets: 46760, Egg: false

Twitter profile fields:
Name: Aaron Patterson
Website: http://t.co/gN1GLubxAe
Tagline: `ひげの山男
Job: GitHub
Opinions: Mine

When I'm not trimming my beard, I'm hanging out with my wife, @ebiltwin.`

Personal page: http://github.com/tenderlove
Organization description: Collaborative Coding
Organization country: USA

Signature file contents:
```
---
  name: "Aaron Patterson"
  link: https://twitter.com/tenderlove
  organization: "GitHub"
  occupation_title: "Systems Engineer"
---
```