### PR TITLE
SignBot: Add signatory 'C. Scott Ananian' (cscottnet)

### DIFF
--- a/_signatures/yDDlNisrxkOAix1dHOdKisBgsQZ2.md
+++ b/_signatures/yDDlNisrxkOAix1dHOdKisBgsQZ2.md
@@ -1,0 +1,6 @@
+---
+  name: "C. Scott Ananian"
+  link: https://cscott.net
+  organization: "Wikimedia Foundation"
+  occupation_title: "Senior Features Engineer"
+---


### PR DESCRIPTION
Twitter user: [https://twitter.com/cscottnet](https://twitter.com/cscottnet)
Created: 2009-05-08 20:28:08 +0000 UTC, Followers: 252, Following: 169, Tweets: 1091, Egg: false

Twitter profile fields:
Name: C. Scott Ananian
Website: http://t.co/NWUuWwO3th
Tagline: `C. Scott is often wrong`

Personal page: https://wikimediafoundation.org/wiki/User:CAnanian_(WMF)
Organization description: Supports and operates Wikipedia and the other free knowledge projects.
Organization country: USA

Signature file contents:
```
---
  name: "C. Scott Ananian"
  link: https://cscott.net
  organization: "Wikimedia Foundation"
  occupation_title: "Senior Features Engineer"
---
```