### PR TITLE
SignBot: Add signatory 'Tracy Chou' (triketora)

### DIFF
--- a/_signatures/wJpCbLpGn8drZMpFYGvEIOyxgx43.md
+++ b/_signatures/wJpCbLpGn8drZMpFYGvEIOyxgx43.md
@@ -1,0 +1,6 @@
+---
+  name: "Tracy Chou"
+  link: https://twitter.com/triketora
+  organization: "Project Include"
+  occupation_title: "Software Engineer"
+---


### PR DESCRIPTION
Twitter user: [https://twitter.com/triketora](https://twitter.com/triketora)
Created: 2009-01-26 20:42:19 +0000 UTC, Followers: 33047, Following: 917, Tweets: 28453, Egg: false

Twitter profile fields:
Name: Tracy Chou
Website: https://t.co/UZsag9Tf7n
Tagline: `tbd. @projectinclude founding team. @homebrew advisor. previously @pinterest, @usds, @quora, @stanford. i turn coffee into code. i like yoga and running.`

Personal page: triketora.com
Organization description: Project Include is a non-profit dedicated to solutions around diversity in tech.
Organization country: USA

Signature file contents:
```
---
  name: "Tracy Chou"
  link: https://twitter.com/triketora
  organization: "Project Include"
  occupation_title: "Software Engineer"
---
```