### PR TITLE
SignBot: Add signatory 'Holly Bowen' (pipsqueaky)

### DIFF
--- a/_signatures/QtkLKMOJNNSP28wqsfyiN5OwSDA2.md
+++ b/_signatures/QtkLKMOJNNSP28wqsfyiN5OwSDA2.md
@@ -1,0 +1,6 @@
+---
+  name: "Holly Bowen"
+  link: https://twitter.com/pipsqueaky
+  organization: "ThoughtWorks"
+  occupation_title: "Lead Developer"
+---


### PR DESCRIPTION
Twitter user: [https://twitter.com/pipsqueaky](https://twitter.com/pipsqueaky)
Created: 2007-05-12 13:43:28 +0000 UTC, Followers: 292, Following: 281, Tweets: 3560, Egg: false

Twitter profile fields:
Name: 3 oz of whoop-ass
Website: 
Tagline: `Holly Bowen (or "Pips" if you're fannish). Member of the progressive resistance. Super-dev at ThoughtWorks.`

Personal page: https://www.thoughtworks.com/profiles/holly-bowen
Organization description: Software consulting & delivery
Organization country: United States

Signature file contents:
```
---
  name: "Holly Bowen"
  link: https://twitter.com/pipsqueaky
  organization: "ThoughtWorks"
  occupation_title: "Lead Developer"
---
```