### PR TITLE
Add link to accountability guides

### DIFF
--- a/_includes/resources.html
+++ b/_includes/resources.html
@@ -6,7 +6,7 @@
 
 <ul>
   <li><a href="https://blog.torproject.org/blog/technology-hostile-states-ten-principles-user-protection">Technology in Hostile States: Ten Principles for User Protection</a> by Mike Perry</li>
-  <li><a href="https://accountability-guides.github.io/">Accountability Guides</a> to hold yourself and your organization accountable to the neveragain.tech pledge</li> 
+  <li><a href="https://accountability-guides.github.io/">Accountability Guides</a> to hold your organization and yourself accountable to the neveragain.tech pledge</li> 
 </ul>
 
 <h2>Donate</h2>

--- a/_includes/resources.html
+++ b/_includes/resources.html
@@ -6,6 +6,7 @@
 
 <ul>
   <li><a href="https://blog.torproject.org/blog/technology-hostile-states-ten-principles-user-protection">Technology in Hostile States: Ten Principles for User Protection</a> by Mike Perry</li>
+  <li><a href="https://accountability-guides.github.io/">Accountability Guides</a> to hold yourself and your organization accountable to the neveragain.tech pledge</li> 
 </ul>
 
 <h2>Donate</h2>


### PR DESCRIPTION
Adds a link to https://accountability-guides.github.io/ to the resources page.

The accountability guides site contains two kinds of guides for helping people hold their organizations and themselves accountable to the neveragain.tech pledge:
- **Organization guide:** A set of questions that a group can use to develop a body of knowledge  to help them navigate problematic situations.
- **Personal guide:** A set of questions for helping an individual assess their current situation, make a plan, and ask others to hold them accountable to it.

There is only one organization guide right now and it's fairly basic. I am encouraging people to open issues or PRs to suggest/add more guides for different kinds of organizations and audiences: https://github.com/accountability-guides/accountability-guides.github.io/blob/master/CONTRIBUTING.md